### PR TITLE
Snyk extension implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+insert_final_newline = true
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{json,js,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "@sourcegraph/eslint-config"
+  ],
+  "parserOptions": {
+    "project": "tsconfig.json"
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.cache/
+dist/
+lib/
+node_modules/
+/.nyc_output/
+yarn.lock
+/coverage/
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# npm audit (Sourcegraph extension)
+# Snyk Sourcegraph extension
+
+
+## Configuration
+
+The extension can be configured through JSON in user, organization or global settings.
+
+```jsonc
+{
+  // A Snyk API token.
+  "snyk.apiToken": "...",
+
+  // The Snyk extension needs to map the repository on Sourcegraph to a project inside an organization on
+  // Snyk. The default settings work for most projects on Snyk, but if you have a custom setup, you
+  // can configure the following settings.
+
+  // This regular expression is matched on the repository name. The values from the capture groups are
+  // available in the templates below.
+  "snyk.repositoryNamePattern": "(?:^|/)([^/]+)/([^/]+)$",
+  // This template is used to form the Snyk organization key.
+  // By default, the second-last part of the repository name (first capture group above) is used as-is.
+  // E.g. "apache" from "github.com/apache/struts".
+  "snyk.organizationKeyTemplate": "$1",
+
+  // CORS headers are necessary for the extension to fetch data, but Snyk does not send them by default.
+  // Here you can customize the URL to an HTTP proxy that adds CORS headers.
+  // By default Sourcegraph's CORS proxy is used.
+  "snyk.corsAnywhereUrl": "https://cors-anywhere.herokuapp.com"
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# npm audit (Sourcegraph extension)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # Snyk Sourcegraph extension
 
 
+### Code Insight
+
+<p>
+<picture>
+<source srcset="https://user-images.githubusercontent.com/37420160/97132254-b948a100-171c-11eb-8dac-d0c02b4ca946.png" media="(prefers-color-scheme: dark)">
+<source srcset="https://user-images.githubusercontent.com/37420160/97132234-ac2bb200-171c-11eb-84ac-949c60ceeb82.png" media="(prefers-color-scheme: light)">
+<img src="https://user-images.githubusercontent.com/37420160/97132234-ac2bb200-171c-11eb-84ac-949c60ceeb82.png" alt="Screenshot">
+</picture>
+</p>
+
+
+### Notification + Panel View
+
+<p>
+<picture>
+<source srcset="https://user-images.githubusercontent.com/37420160/97132302-d8dfc980-171c-11eb-9d5d-36379841cb3e.png" media="(prefers-color-scheme: dark)">
+<source srcset="https://user-images.githubusercontent.com/37420160/97132290-cf566180-171c-11eb-8914-2c39d58cf593.png" media="(prefers-color-scheme: light)">
+<img src="https://user-images.githubusercontent.com/37420160/97132290-cf566180-171c-11eb-8914-2c39d58cf593.png" alt="Screenshot">
+</picture>
+</p>
+
+
+
 ## Configuration
 
 The extension can be configured through JSON in user, organization or global settings.
@@ -9,6 +32,9 @@ The extension can be configured through JSON in user, organization or global set
 {
   // A Snyk API token.
   "snyk.apiToken": "...",
+
+  // Whether to show notifications when Snyk has found issues in the currently viewed project
+  "snyk.showNotifications": true,
 
   // The Snyk extension needs to map the repository on Sourcegraph to a project inside an organization on
   // Snyk. The default settings work for most projects on Snyk, but if you have a custom setup, you

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Snyk Sourcegraph extension
 
+Provides code insights from Snyk reports.
+
+**Status**: beta
 
 ### Code Insight
 

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,0 +1,4 @@
+  --recursive
+ --watch-extensions ts
+ --timeout 200
+ src/**/*.test.ts

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "title": "Show panel",
         "actionItem": {
           "label": "Snyk",
-          "description": "See TODO"
+          "description": "See issues from the current project"
         }
       }
     ],
@@ -43,6 +43,10 @@
       "snyk.apiToken": {
         "description": "A Snyk API token",
         "type": "string"
+      },
+      "snyk.showNotifications": {
+        "description": "Whether to show notifications when Snyk has found issues in the current project",
+        "type": "boolean"
       },
       "snyk.repositoryNamePattern": {
         "description": "Regular expression with that is matched on the repository name to extract the capture groups for organization and project key templates.",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,21 @@
         "description": "The URL to a CORS proxy.",
         "type": "string",
         "default": "https://cors-anywhere.herokuapp.com"
+      },
+      "snyk.apiToken": {
+        "description": "A Snyk API token",
+        "type": "string"
+      },
+      "snyk.repositoryNamePattern": {
+        "description": "Regular expression with that is matched on the repository name to extract the capture groups for organization and project key templates.",
+        "type": "string",
+        "format": "regex",
+        "default": "(?:^|/)([^/]+)/([^/]+)$"
+      },
+      "snyk.organizationKeyTemplate": {
+        "description": "Replace string to build the organization key from the repository name pattern, using $n references for capture groups. By default just uses the first capture group",
+        "type": "string",
+        "default": "$1"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/client/shared/src/schema/extension.schema.json",
   "name": "snyk",
-  "description": "",
+  "description": "Provides code insights from Snyk reports",
   "publisher": "sourcegraph",
   "activationEvents": [
     "*"
@@ -119,5 +119,8 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "rxjs": "^6.6.3"
+  },
+  "repository": {
+    "url": "https://github.com/sourcegraph/sourcegraph-snyk"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/client/shared/src/schema/extension.schema.json",
   "name": "snyk",
-  "description": "Snyk TODO",
+  "description": "",
   "publisher": "sourcegraph",
   "activationEvents": [
     "*"

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@sourcegraph/prettierrc')

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,7 +46,6 @@ export interface ProjectIssues {
     issues: Issue[]
 }
 
-// TODO narrow types.
 export interface Issue {
     id: string
     issueType: string
@@ -55,7 +54,7 @@ export interface Issue {
     issueData: {
         id: string
         title: string
-        severity: string
+        severity: 'low' | 'medium' | 'high'
         url: string
         description: string
         identifiers: {
@@ -93,8 +92,7 @@ async function fetchApi(path: string, options: ApiOptions, init?: RequestInit): 
     headers.set('Authorization', 'token ' + options.apiToken)
     const response = await fetch(url.href, { headers, ...init })
     if (!response.ok) {
-        console.log(response)
-        throw new Error('TODO')
+        throw new Error(response.statusText)
     }
     const result = await response.json()
     return result
@@ -112,7 +110,11 @@ export async function listAggregatedProjectIssues(
     projectId: string,
     options: ApiOptions
 ): Promise<{ issues: Issue[] }> {
-    return fetchApi(`api/v1/org/${encodeURIComponent(orgId)}/project/${encodeURI(projectId)}/aggregated-issues`, options, { method: 'POST' })
+    return fetchApi(
+        `api/v1/org/${encodeURIComponent(orgId)}/project/${encodeURI(projectId)}/aggregated-issues`,
+        options,
+        { method: 'POST' }
+    )
 }
 
 interface OrgsListResponse {
@@ -143,9 +145,9 @@ function memoizeAsync<P, T>(
         if (hit) {
             return hit
         }
-        const p = func(parameters)
-        p.then(null, () => cache.delete(key))
-        cache.set(key, p)
-        return p
+        const promise = func(parameters)
+        promise.then(null, () => cache.delete(key))
+        cache.set(key, promise)
+        return promise
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,151 @@
+export interface ApiOptions {
+    snykApiUrl: URL
+
+    /** API authentication token */
+    apiToken: string
+}
+
+export interface AllProjectsResponse {
+    org: {
+        name: string
+        id: string
+    }
+    projects: Project[]
+}
+
+export interface Project {
+    name: string
+    id: string
+    created: string
+    origin: string
+    type: string
+    readOnly: string
+    testFrequency: string
+    totalDependencies: number
+    issueCountsBySeverity: {
+        low: number
+        high: number
+        medium: number
+    }
+    remoteRepoUrl?: string
+    lastTestedDate: string
+    browseUrl?: string
+    importingUser: {
+        id: string
+        name: string
+        username: string
+        email: string
+    }
+    isMonitored: boolean
+    owner: { id: string; name: string; username: string; email: string }
+    branch: string
+    tags: { key: string; value: string }[]
+}
+
+export interface ProjectIssues {
+    issues: Issue[]
+}
+
+// TODO narrow types.
+export interface Issue {
+    id: string
+    issueType: string
+    pkgName: string
+    pkgVersions: string[]
+    issueData: {
+        id: string
+        title: string
+        severity: string
+        url: string
+        description: string
+        identifiers: {
+            CVE: string[]
+            CWE: string[]
+            ALTERNATIVE: string[]
+        }
+        credit: string[]
+        exploitMaturity: string
+        semver: Record<string, string[]>
+        publicationTime: string
+        disclosureTime: string
+        CVSSv3: string
+        cvssScore: number
+        language: string
+        patches: { id: string; urls: string[]; version: string; comments: string[]; modificationTime: string }[]
+        nearestFixedInVersion: string
+    }
+    isPatched: boolean
+    isIgnored: boolean
+    fixInfo: { isUpgradable: boolean; isPinnable: boolean; isPatchable: boolean; nearestFixedInVersion: string }
+    priority: {
+        score: number
+        factors: { name: string; description: string }[]
+    }
+}
+
+async function fetchApi(path: string, options: ApiOptions, init?: RequestInit): Promise<any> {
+    const url = new URL(path, options.snykApiUrl)
+    console.log({
+        optURL: options.snykApiUrl.href,
+        genURL: url.href,
+    })
+    const headers = new Headers()
+    headers.set('Authorization', 'token ' + options.apiToken)
+    const response = await fetch(url.href, { headers, ...init })
+    if (!response.ok) {
+        console.log(response)
+        throw new Error('TODO')
+    }
+    const result = await response.json()
+    return result
+}
+
+export const listAllProjects = memoizeAsync(
+    async ({ orgId, options }: { orgId: string; options: ApiOptions }): Promise<AllProjectsResponse> =>
+        fetchApi(`api/v1/org/${encodeURIComponent(orgId)}/projects`, options, { method: 'POST' }),
+    ({ orgId, options }) => `${orgId}-${options.apiToken}`
+)
+
+// Don't memoize this as it can change more often (commits)
+export async function listAggregatedProjectIssues(
+    orgId: string,
+    projectId: string,
+    options: ApiOptions
+): Promise<{ issues: Issue[] }> {
+    return fetchApi(`api/v1/org/${encodeURIComponent(orgId)}/project/${encodeURI(projectId)}/aggregated-issues`, options, { method: 'POST' })
+}
+
+interface OrgsListResponse {
+    orgs: { name: string; id: string; slug: string; url: string; group: null | { name: string; id: string } }[]
+}
+
+export const getUserOrgs = memoizeAsync(
+    async (options: ApiOptions): Promise<OrgsListResponse> => fetchApi('api/v1/orgs', options),
+    options => options.apiToken
+)
+
+/**
+ * Creates a function that memoizes the async result of func. If the Promise is rejected, the result will not be
+ * cached.
+ *
+ * @param func The function to memoize
+ * @param toKey Determines the cache key for storing the result based on the first argument provided to the memoized
+ * function
+ */
+function memoizeAsync<P, T>(
+    func: (parameters: P) => Promise<T>,
+    toKey: (parameters: P) => string
+): (parameters: P) => Promise<T> {
+    const cache = new Map<string, Promise<T>>()
+    return (parameters: P) => {
+        const key = toKey(parameters)
+        const hit = cache.get(key)
+        if (hit) {
+            return hit
+        }
+        const p = func(parameters)
+        p.then(null, () => cache.delete(key))
+        cache.set(key, p)
+        return p
+    }
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -56,7 +56,7 @@ export interface Issue {
         title: string
         severity: 'low' | 'medium' | 'high'
         url: string
-        description: string
+        description?: string
         identifiers: {
             CVE: string[]
             CWE: string[]

--- a/src/snyk.test.ts
+++ b/src/snyk.test.ts
@@ -3,17 +3,25 @@ import mock from 'mock-require'
 const sourcegraph = createStubSourcegraphAPI()
 mock('sourcegraph', sourcegraph)
 
-import { getClosestProject, } from './snyk'
+import { getClosestProject } from './snyk'
 import * as assert from 'assert'
+import { Project } from './api'
 
 describe('snyk', () => {
-    describe('getClosestPackageJSON()', () => {
-        it('works when TODO', () => {
-            assert.strictEqual(getClosestProject('', '', []), 'TODO')
+    describe('getClosestProject()', () => {
+        it('works with multiple projects in one repository', () => {
+            const projects = [
+                { name: 'sourcegraph/sourcegraph-snyk:client/shared/src/api/package.json' },
+                { name: 'sourcegraph/sourcegraph:package.json' },
+                { name: 'sourcegraph/sourcegraph:client/web/package.json' },
+                { name: 'sourcegraph/sourcegraph:client/shared/package.json' },
+            ] as Project[]
+            const shortRepoName = 'sourcegraph/sourcegraph'
+            const filePath = 'client/shared/src/api/index.ts'
+            assert.deepStrictEqual(getClosestProject(shortRepoName, filePath, projects), {
+                name: 'sourcegraph/sourcegraph:client/shared/package.json',
+                manifestFilePath: 'client/shared/package.json',
+            })
         })
     })
-
-    // packageToAuditBody()
-
-    // auditResponseToMarkdown()
 })

--- a/src/snyk.test.ts
+++ b/src/snyk.test.ts
@@ -3,13 +3,13 @@ import mock from 'mock-require'
 const sourcegraph = createStubSourcegraphAPI()
 mock('sourcegraph', sourcegraph)
 
-import { getClosestPackageJSON, } from './npmAudit'
+import { getClosestProject, } from './snyk'
 import * as assert from 'assert'
 
-describe('npm audit', () => {
+describe('snyk', () => {
     describe('getClosestPackageJSON()', () => {
         it('works when TODO', () => {
-            assert.strictEqual(getClosestPackageJSON('', []), 'TODO')
+            assert.strictEqual(getClosestProject('', '', []), 'TODO')
         })
     })
 

--- a/src/snyk.test.ts
+++ b/src/snyk.test.ts
@@ -1,0 +1,19 @@
+import { createStubSourcegraphAPI } from '@sourcegraph/extension-api-stubs'
+import mock from 'mock-require'
+const sourcegraph = createStubSourcegraphAPI()
+mock('sourcegraph', sourcegraph)
+
+import { getClosestPackageJSON, } from './npmAudit'
+import * as assert from 'assert'
+
+describe('npm audit', () => {
+    describe('getClosestPackageJSON()', () => {
+        it('works when TODO', () => {
+            assert.strictEqual(getClosestPackageJSON('', []), 'TODO')
+        })
+    })
+
+    // packageToAuditBody()
+
+    // auditResponseToMarkdown()
+})

--- a/src/snyk.test.ts
+++ b/src/snyk.test.ts
@@ -9,18 +9,28 @@ import { Project } from './api'
 
 describe('snyk', () => {
     describe('getClosestProject()', () => {
-        it('works with multiple projects in one repository', () => {
-            const projects = [
-                { name: 'sourcegraph/sourcegraph-snyk:client/shared/src/api/package.json' },
-                { name: 'sourcegraph/sourcegraph:package.json' },
-                { name: 'sourcegraph/sourcegraph:client/web/package.json' },
-                { name: 'sourcegraph/sourcegraph:client/shared/package.json' },
-            ] as Project[]
-            const shortRepoName = 'sourcegraph/sourcegraph'
+        const projects = [
+            { name: 'sourcegraph/sourcegraph-snyk:client/shared/src/api/package.json' },
+            { name: 'sourcegraph/sourcegraph:package.json' },
+            { name: 'sourcegraph/sourcegraph:client/package.json' },
+            { name: 'sourcegraph/sourcegraph:client/web/package.json' },
+            { name: 'sourcegraph/sourcegraph:client/shared/package.json' },
+        ] as Project[]
+        const shortRepoName = 'sourcegraph/sourcegraph'
+
+        it('works for files in a repository with multiple projects', () => {
             const filePath = 'client/shared/src/api/index.ts'
             assert.deepStrictEqual(getClosestProject(shortRepoName, filePath, projects), {
                 name: 'sourcegraph/sourcegraph:client/shared/package.json',
                 manifestFilePath: 'client/shared/package.json',
+            })
+        })
+
+        it('works for directories in a repository with multiple projects', () => {
+            const directoryPath = 'client'
+            assert.deepStrictEqual(getClosestProject(shortRepoName, directoryPath, projects), {
+                name: 'sourcegraph/sourcegraph:client/package.json',
+                manifestFilePath: 'client/package.json'
             })
         })
     })

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -55,7 +55,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                     }
 
                     return {
-                        title: `Snyk Report for ${project.name}`,
+                        title: `Snyk report for ${project.name}`,
                         subtitle: `Issues by severity on the default branch (${project.branch})`,
                         content: [
                             {
@@ -226,7 +226,8 @@ function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues)
     markdownString += '\n'
 
     for (const issue of projectIssues.issues) {
-        markdownString += `\n\n#### [${issue.issueData.title}](${issue.issueData.url})\n- dependency: ${
+        console.log(issue)
+        markdownString += `\n\n#### [${issue.issueData.title}](${issue.issueData.url}) (Priority Score: ${issue.priority.score})\n- dependency: ${
             issue.pkgName
         }, version${issue.pkgVersions.length > 1 ? 's' : ''} ${issue.pkgVersions.join(', ')}\n- severity: ${
             issue.issueData.severity

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -157,11 +157,15 @@ function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues,
     return markdownString
 }
 
-export function getClosestProject(shortRepoName: string, filePath: string, allProjects: Project[]): Project {
+export function getClosestProject(
+    shortRepoName: string,
+    filePath: string,
+    allProjects: Project[]
+): Project & { manifestFilePath: string } {
     // filter out projects wihout same repo name
     const projects = allProjects.filter(({ name }) => name.includes(shortRepoName))
 
-    // get manifest file paths (maintain reference to project somehow.. id?)
+    // get manifest file paths
     const projectsWithManifestPath = projects.map(project => ({
         ...project,
         manifestFilePath: project.name.split(shortRepoName)[1]?.replace(/^:/, ''),

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -86,51 +86,11 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                         // Get the closest project to this file in this repo
                         const closestProject = getClosestProject(shortRepoName, filePath, allProjects.projects)
 
-                        // Problems in big monorepos:
-                        // - Could cause false positives for files of languages unsupported by Snyk: the closest
-                        // manifest file would be for a different language.
-
                         if (!closestProject) {
                             throw new NoProjectFoundError(filePath, shortRepoName)
                         }
 
                         const projectIssues = await listAggregatedProjectIssues(orgId, closestProject.id, apiOptions)
-
-                        // TODO: Only decorate lines on latest revision of default branch, since Snyk only monitors the default branch
-                        // https://support.snyk.io/hc/en-us/articles/360001497578-Which-branch-does-Snyk-Monitor
-                        // We should revisit this extension once we have support for uploading org-wide data
-                        // so site-admins can upload Snyk cli test results, through which they can hack together
-                        // branch support.
-
-                        // const isDefaultBranch = await getIsDefaultBranch(commitID, fullRepoName)
-
-                        // const dependencyNames: string[] = []
-                        // const dependencyIndex: Record<string, number | undefined> = {}
-                        // if (isDefaultBranch) {
-                        //     // Merge patterns (predefined + user-defined)
-                        //     const mergedImportPatterns = mergeImportPatterns(
-                        //         predefinedPatterns,
-                        //         config['snyk.importPatterns']
-                        //     )
-                        //     console.log('merged imppats', mergedImportPatterns)
-
-                        //     const text = editor.document.text ?? ''
-                        //     let match: RegExpExecArray | null = null
-
-                        //     const patterns = mergedImportPatterns[editor.document.languageId]
-                        //     if (patterns) {
-                        //         for (let { pattern, matchIndex } of patterns) {
-                        //             if (typeof pattern === 'string') {
-                        //                 pattern = new RegExp(pattern)
-                        //             }
-                        //             while ((match = pattern.exec(text))) {
-                        //                 const name = match[matchIndex]
-                        //                 dependencyNames.push(name)
-                        //                 dependencyIndex[name] = match.index
-                        //             }
-                        //         }
-                        //     }
-                        // }
 
                         return { editor, projectIssues, project: closestProject }
                     } catch (error) {
@@ -171,25 +131,6 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             })
     )
 }
-
-// function mergeImportPatterns(
-//     predefinedPatterns: ImportPatternsByLanguage,
-//     userDefinedPatterns?: ImportPatternsByLanguage
-// ): ImportPatternsByLanguage {
-//     if (!userDefinedPatterns) {
-//         return predefinedPatterns
-//     }
-
-//     return deepmerge(predefinedPatterns, userDefinedPatterns)
-// }
-
-// async function getIsDefaultBranch(commitID: string, fullRepoName: string): Promise<boolean> {
-//     try {
-//         return false
-//     } catch {
-//         return false
-//     }
-// }
 
 function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues, browseUrl?: string): string {
     if (projectIssues.issues.length === 0) {

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -137,23 +137,26 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                         //     }
                         // }
 
-                        return { projectIssues, userAlreadyNotified, browseUrl: closestProject.browseUrl }
+                        return { projectIssues, userAlreadyNotified, project: closestProject }
                     } catch (error) {
                         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                         return { error }
                     }
                 })
             )
-            .subscribe(({ projectIssues, userAlreadyNotified, browseUrl, error }) => {
-                // Panel content
-                // const markdownString = auditResponseToMarkdown(auditResponse, moduleNames)
-                // panelView.content = markdownString
-                if (projectIssues) {
-                    panelView.content = projectIssuesToMarkdown(projectIssues, browseUrl)
+            .subscribe(({ projectIssues, userAlreadyNotified, project, error }) => {
+                if (projectIssues && project) {
+                    panelView.content = projectIssuesToMarkdown(projectIssues, project?.browseUrl)
 
                     if (projectIssues.issues.length > 0 && !userAlreadyNotified) {
                         sourcegraph.app.activeWindow?.showNotification(
-                            'Snyk has found issues in the default branch () of your project. [See more info](#tab=snyk.panel)',
+                            `Snyk has found issues in the default branch${
+                                project.branch ? ` (${project.branch})` : ''
+                            } of project${
+                                project.name ? ` ${project.name}` : ' '
+                            }. See more info on [Sourcegraph](#tab=snyk.panel)${
+                                project.browseUrl ? ` or [Snyk](${project.browseUrl})` : ''
+                            }`,
                             sourcegraph.NotificationType.Warning
                         )
                     }

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -1,0 +1,285 @@
+import { combineLatest, EMPTY, from } from 'rxjs'
+import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators'
+import * as sourcegraph from 'sourcegraph'
+import { ApiOptions, getUserOrgs, listAggregatedProjectIssues, listAllProjects, Project, ProjectIssues } from './api'
+
+interface Configuration {
+    'snyk.corsAnywhereUrl'?: string
+    'snyk.apiToken'?: string
+    'snyk.repositoryNamePattern'?: string
+    'snyk.organizationKeyTemplate'?: string
+}
+
+const getConfig = (): Configuration => sourcegraph.configuration.get<Configuration>().value
+
+export function activate(context: sourcegraph.ExtensionContext): void {
+    const panelView = sourcegraph.app.createPanelView('snyk.panel')
+    panelView.title = 'Snyk'
+    panelView.content = 'TODO to see audit results'
+
+    // Don't show multiple alerts for the same project in the same session
+    const shownProjectAlerts = new Set<string>()
+
+    context.subscriptions.add(
+        combineLatest([
+            from(sourcegraph.app.activeWindowChanges).pipe(
+                switchMap(activeWindow => activeWindow?.activeViewComponentChanges || EMPTY),
+                filter((viewer): viewer is sourcegraph.CodeEditor => !!viewer && viewer.type === 'CodeEditor'),
+                distinctUntilChanged((a, b) => a.document === b.document)
+            ),
+            from(sourcegraph.configuration).pipe(map(() => getConfig())),
+        ])
+            .pipe(
+                switchMap(async ([editor, config]) => {
+                    try {
+                        // Construct API Options
+                        const corsAnywhereUrl = new URL(
+                            (config['snyk.corsAnywhereUrl']?.replace(/\/$/, '') ||
+                                'https://cors-anywhere.herokuapp.com') + '/'
+                        )
+
+                        console.log(config)
+                        const apiToken = config['snyk.apiToken']
+                        if (!apiToken) {
+                            throw new Error('TODO no API token')
+                        }
+                        const snykBaseUrl = new URL('https://snyk.io/')
+                        const apiOptions: ApiOptions = {
+                            snykApiUrl: new URL(
+                                `${corsAnywhereUrl.href.replace(/\/$/, '')}/${snykBaseUrl.href.replace(/\/$/, '')}/`
+                            ),
+                            apiToken,
+                        }
+                        panelView.content = 'Loading...'
+                        const uri = new URL(editor.document.uri)
+                        const shortRepoName = decodeURIComponent(uri.pathname).replace(/^\//, '')
+                        const filePath = decodeURIComponent(uri.hash.slice(1))
+
+                        const repositoryNamePattern = '(?:^|/)([^/]+)/([^/]+)$'
+                        const repositoryNameMatch = shortRepoName.match(repositoryNamePattern)
+
+                        if (!repositoryNameMatch) {
+                            throw new Error(
+                                `repositoryNamePattern ${repositoryNamePattern.toString()} did not match repository name ${shortRepoName}`
+                            )
+                        }
+
+                        const organizationKeyTemplate = config['snyk.organizationKeyTemplate'] ?? '$1'
+                        const orgId = organizationKeyTemplate.replace(/\$(\d)/g, (substring, number: string) => {
+                            console.log({ substring, number, repositoryNameMatch })
+                            return repositoryNameMatch[+number]
+                        })
+
+                        // Get list of orgs that this user is part of
+                        const orgsList = await getUserOrgs(apiOptions)
+                        const org = orgsList.orgs.find(({ name }) => name === orgId)
+
+                        if (!org) {
+                            throw new OrgNotFoundError(orgId)
+                        }
+
+                        // Check if Snyk has info for this project. We need this step because shortRepoName is not a valid project ID
+                        const allProjects = await listAllProjects({ orgId, options: apiOptions })
+
+                        // Get the closest project to this file in this repo
+                        const closestProject = getClosestProject(shortRepoName, filePath, allProjects.projects)
+                        console.log({
+                            allProjects,
+                            closestProject,
+                        })
+
+                        const userAlreadyNotified = shownProjectAlerts.has(closestProject.name)
+
+                        // Problems in big monorepos:
+                        // - Could cause false positives for files of languages unsupported by Snyk, so the closest
+                        // manifest file would be of a different language. Is that a big concern?
+
+                        if (!closestProject) {
+                            throw new NoProjectFoundError(filePath, shortRepoName)
+                        }
+
+                        const projectIssues = await listAggregatedProjectIssues(orgId, closestProject.id, apiOptions)
+                        console.log('projectIssues', projectIssues)
+
+                        // TODO: Only decorate lines on latest revision of default branch, since Snyk only monitors the default branch
+                        // https://support.snyk.io/hc/en-us/articles/360001497578-Which-branch-does-Snyk-Monitor
+                        // We should revisit this extension once we have support for uploading org-wide data
+                        // so site-admins can upload Snyk cli test results, through which they can hack together
+                        // branch support.
+
+                        // const isDefaultBranch = await getIsDefaultBranch(commitID, fullRepoName)
+
+                        // const dependencyNames: string[] = []
+                        // const dependencyIndex: Record<string, number | undefined> = {}
+                        // if (isDefaultBranch) {
+                        //     // Merge patterns (predefined + user-defined)
+                        //     const mergedImportPatterns = mergeImportPatterns(
+                        //         predefinedPatterns,
+                        //         config['snyk.importPatterns']
+                        //     )
+                        //     console.log('merged imppats', mergedImportPatterns)
+
+                        //     const text = editor.document.text ?? ''
+                        //     let match: RegExpExecArray | null = null
+
+                        //     const patterns = mergedImportPatterns[editor.document.languageId]
+                        //     if (patterns) {
+                        //         for (let { pattern, matchIndex } of patterns) {
+                        //             if (typeof pattern === 'string') {
+                        //                 pattern = new RegExp(pattern)
+                        //             }
+                        //             while ((match = pattern.exec(text))) {
+                        //                 const name = match[matchIndex]
+                        //                 dependencyNames.push(name)
+                        //                 dependencyIndex[name] = match.index
+                        //             }
+                        //         }
+                        //     }
+                        // }
+
+                        return { projectIssues, userAlreadyNotified, browseUrl: closestProject.browseUrl }
+                    } catch (error) {
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                        return { error }
+                    }
+                })
+            )
+            .subscribe(({ projectIssues, userAlreadyNotified, browseUrl, error }) => {
+                // Panel content
+                // const markdownString = auditResponseToMarkdown(auditResponse, moduleNames)
+                // panelView.content = markdownString
+                if (projectIssues) {
+                    panelView.content = projectIssuesToMarkdown(projectIssues, browseUrl)
+
+                    if (projectIssues.issues.length > 0 && !userAlreadyNotified) {
+                        sourcegraph.app.activeWindow?.showNotification(
+                            'Snyk has found issues in the default branch () of your project. [See more info](#tab=snyk.panel)',
+                            sourcegraph.NotificationType.Warning
+                        )
+                    }
+                } else if (error) {
+                    if (error instanceof NoProjectFoundError || error instanceof OrgNotFoundError) {
+                        console.error(error.message)
+                        panelView.content = error.message
+                    } else {
+                        console.error(error)
+                        panelView.content = 'Unknown error fetching issues for this file'
+                    }
+                }
+            })
+    )
+}
+
+// function mergeImportPatterns(
+//     predefinedPatterns: ImportPatternsByLanguage,
+//     userDefinedPatterns?: ImportPatternsByLanguage
+// ): ImportPatternsByLanguage {
+//     if (!userDefinedPatterns) {
+//         return predefinedPatterns
+//     }
+
+//     return deepmerge(predefinedPatterns, userDefinedPatterns)
+// }
+
+// async function getIsDefaultBranch(commitID: string, fullRepoName: string): Promise<boolean> {
+//     try {
+//         return false
+//     } catch {
+//         return false
+//     }
+// }
+
+function projectIssuesToMarkdown(projectIssues: ProjectIssues, browseUrl?: string): string {
+    // Important: link to browse URL at top if user would prefer Snyk's UI
+    if (projectIssues.issues.length === 0) {
+        return `No issues found for this project.${browseUrl ? ` [See the full report](${browseUrl})` : ''}`
+    }
+
+    // Collapsible issues are nice... see if our markdown renderer can handle it (2 new lines after summary elem)
+
+    // Check
+
+    return 'you gotta lotta issues'
+}
+
+function getClosestProject(shortRepoName: string, filePath: string, allProjects: Project[]): Project {
+    // filter out projects wihout same repo name
+    const projects = allProjects.filter(({ name }) => name.includes(shortRepoName))
+
+    // get manifest file paths (maintain reference to project somehow.. id?)
+    const projectsWithManifestPath = projects.map(project => ({
+        ...project,
+        manifestFilePath: project.name.split(shortRepoName)[1]?.replace(/^:/, ''),
+    }))
+
+    interface Tree {
+        manifest?: { type: string; projectIndex: number }
+        trees: Record<string, Tree | undefined>
+    }
+
+    const fileTree: { root: Tree } = { root: { trees: {} } }
+
+    // construct file tree
+    for (const [projectIndex, { manifestFilePath }] of projectsWithManifestPath.entries()) {
+        // TODO why
+        if (manifestFilePath === undefined) {
+            continue
+        }
+        const pathComponents = manifestFilePath.split('/')
+        // No leading slashes AFAIK
+        let cwd = fileTree.root
+        for (const [componentIndex, component] of pathComponents.entries()) {
+            // Last component, so this is a file
+            if (componentIndex === pathComponents.length - 1) {
+                cwd.manifest = { type: component, projectIndex }
+                break
+            }
+            // If the tree doesn't already exist, create it
+            const nextTree = cwd.trees[component] ?? { blobs: {}, trees: {} }
+            // Reassign in case it didn't exist before
+            cwd.trees[component] = nextTree
+            cwd = nextTree
+        }
+    }
+
+    // find lowest ancestor manifest
+    let deepestAncestorManifest = 0
+    let cwd: Tree | undefined = fileTree.root
+    for (const component of filePath.split('/')) {
+        if (!cwd) {
+            break
+        }
+        const maybeManifest = cwd.manifest
+        if (maybeManifest) {
+            deepestAncestorManifest = maybeManifest.projectIndex
+        }
+        cwd = cwd.trees[component]
+    }
+
+    return projectsWithManifestPath[deepestAncestorManifest]
+}
+
+// Error types
+
+class UserAlreadyNotifiedError extends Error {
+    public readonly name = 'UserAlreadyNotifiedError'
+    constructor(projectName: string) {
+        super(`User has already been notified that project: ${projectName} has vulnerabilities`)
+    }
+}
+
+class NoProjectFoundError extends Error {
+    public readonly name = 'NoProjectFoundError'
+    constructor(filePath: string, shortRepoName: string) {
+        super(`No Snyk project has been found for file: ${filePath} in repo: ${shortRepoName}`)
+    }
+}
+
+class OrgNotFoundError extends Error {
+    public readonly name = 'OrgNotFoundError'
+    constructor(orgId: string) {
+        super(`No org with id: ${orgId} has was found`)
+    }
+}
+
+// Sourcegraph extension documentation: https://docs.sourcegraph.com/extensions/authoring

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -30,7 +30,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
             from(sourcegraph.configuration).pipe(map(() => getConfig())),
         ])
             .pipe(
-                tap(() => panelView.content = 'Loading...'),
+                tap(() => (panelView.content = 'Loading...')),
                 switchMap(async ([editor, config]) => {
                     try {
                         // Construct API Options
@@ -57,7 +57,7 @@ export function activate(context: sourcegraph.ExtensionContext): void {
                         const shortRepoName = decodeURIComponent(uri.pathname).replace(/^\//, '')
                         const filePath = decodeURIComponent(uri.hash.slice(1))
 
-                        const repositoryNamePattern = '(?:^|/)([^/]+)/([^/]+)$'
+                        const repositoryNamePattern = config['snyk.repositoryNamePattern'] || '(?:^|/)([^/]+)/([^/]+)$'
                         const repositoryNameMatch = shortRepoName.match(repositoryNamePattern)
 
                         if (!repositoryNameMatch) {
@@ -139,7 +139,7 @@ function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues,
 
     let markdownString = ''
 
-    markdownString += `### Issues found in ${project.name}` // TODO project name in title
+    markdownString += `### Issues found in ${project.name}`
     if (browseUrl) {
         markdownString += ` [(Read full report on Snyk)](${browseUrl})`
     }

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -216,7 +216,7 @@ function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues,
     return markdownString
 }
 
-function getClosestProject(shortRepoName: string, filePath: string, allProjects: Project[]): Project {
+export function getClosestProject(shortRepoName: string, filePath: string, allProjects: Project[]): Project {
     // filter out projects wihout same repo name
     const projects = allProjects.filter(({ name }) => name.includes(shortRepoName))
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@sourcegraph/tsconfig",
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "sourceMap": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}


### PR DESCRIPTION
<details open>
<summary>JS monorepo with vulnerabilities in multiple projects</summary>
<img src="https://user-images.githubusercontent.com/37420160/96945739-87310800-14ac-11eb-8319-d53554850777.gif" />
</details>

<details>
<summary>Java monorepo with no vulnerabilities</summary>
<img src="https://user-images.githubusercontent.com/37420160/96945742-88623500-14ac-11eb-89e4-20ef64916047.gif" />
</details>

Limitations:
- Snyk only monitors the [default branch](https://support.snyk.io/hc/en-us/articles/360001497578-Which-branch-does-Snyk-Monitor), and they don't return the commit ID at the time they tested the project, so there's no way to guarantee that line decorations are accurate. Would it still be worth decorating import statements, even if there's a chance that the dependency in question is actually of a safe version at the viewed commit? I kept the logic for merged language patterns commented in case we decide to move forward with line decorations (also lives on in [sourcegraph/npm-audit](https://github.com/sourcegraph/sourcegraph-npm-audit/pull/1), so implementation wasn't a total waste).
- See [comment](https://github.com/sourcegraph/sourcegraph-snyk/pull/2#discussion_r510546384)
- Panel links for older alerts are useless, as the panel now contains the report from the latest opened file. 

TODO:
- README pictures once the panel UI is finalized