### PR TITLE
Use own cors-anywhere server

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "snyk.corsAnywhereUrl": {
         "description": "The URL to a CORS proxy.",
         "type": "string",
-        "default": "https://cors-anywhere.herokuapp.com"
+        "default": "https://cors-anywhere.sgdev.org"
       },
       "snyk.apiToken": {
         "description": "A Snyk API token",


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pull/3956, part of https://github.com/sourcegraph/sourcegraph/issues/15794