### PR TITLE
fix: use our CORS proxy as fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Provides code insights from Snyk reports.
 </picture>
 </p>
 
-
 ### Notification + Panel View
 
 <p>
@@ -24,8 +23,6 @@ Provides code insights from Snyk reports.
 <img src="https://user-images.githubusercontent.com/37420160/97132290-cf566180-171c-11eb-8914-2c39d58cf593.png" alt="Screenshot">
 </picture>
 </p>
-
-
 
 ## Configuration
 
@@ -54,7 +51,6 @@ The extension can be configured through JSON in user, organization or global set
   // CORS headers are necessary for the extension to fetch data, but Snyk does not send them by default.
   // Here you can customize the URL to an HTTP proxy that adds CORS headers.
   // By default Sourcegraph's CORS proxy is used.
-  "snyk.corsAnywhereUrl": "https://cors-anywhere.herokuapp.com"
+  "snyk.corsAnywhereUrl": "https://cors-anywhere.sgdev.org"
 }
 ```
-

--- a/src/snyk.ts
+++ b/src/snyk.ts
@@ -158,7 +158,7 @@ async function getSnykReport(
 ): Promise<{ projectIssues: ProjectIssues; project: Project }> {
     // Construct API Options
     const corsAnywhereUrl = new URL(
-        (config['snyk.corsAnywhereUrl']?.replace(/\/$/, '') || 'https://cors-anywhere.herokuapp.com') + '/'
+        (config['snyk.corsAnywhereUrl']?.replace(/\/$/, '') || 'https://cors-anywhere.sgdev.org') + '/'
     )
 
     const apiToken = config['snyk.apiToken']
@@ -227,11 +227,11 @@ function projectIssuesToMarkdown(project: Project, projectIssues: ProjectIssues)
 
     for (const issue of projectIssues.issues) {
         console.log(issue)
-        markdownString += `\n\n#### [${issue.issueData.title}](${issue.issueData.url}) (Priority Score: ${issue.priority.score})\n- dependency: ${
-            issue.pkgName
-        }, version${issue.pkgVersions.length > 1 ? 's' : ''} ${issue.pkgVersions.join(', ')}\n- severity: ${
-            issue.issueData.severity
-        }\n\n`
+        markdownString += `\n\n#### [${issue.issueData.title}](${issue.issueData.url}) (Priority Score: ${
+            issue.priority.score
+        })\n- dependency: ${issue.pkgName}, version${issue.pkgVersions.length > 1 ? 's' : ''} ${issue.pkgVersions.join(
+            ', '
+        )}\n- severity: ${issue.issueData.severity}\n\n`
     }
 
     return markdownString


### PR DESCRIPTION
Our CORS proxy is the default setting value, but we fall back to the public cors-anywhere demo when there's no corsAnywhereUrl in user settings.